### PR TITLE
Updated UI on MainPage

### DIFF
--- a/MauiApp2/LoginPage.xaml.cs
+++ b/MauiApp2/LoginPage.xaml.cs
@@ -10,11 +10,11 @@ namespace MauiApp2;
 
 public partial class LoginPage : ContentPage
 {
+    public string usrnm;
     public LoginPage()
     {
         InitializeComponent();
     }
-    string usrnm;
     string pass;
     IBluetoothLE ble = CrossBluetoothLE.Current;
 
@@ -79,7 +79,7 @@ public partial class LoginPage : ContentPage
             MakeFile("test.txt");
             WriteFile("test.txt", usrnm);
             BluetoothState state = ble.State;
-            Navigation.PushAsync(new MainPage());
+            Navigation.PushAsync(new MainPage(usrnm));
         }
         else DisplayAlert("Alert", "Please Enter Username and Password", "OK");
 

--- a/MauiApp2/MainPage.xaml
+++ b/MauiApp2/MainPage.xaml
@@ -17,7 +17,9 @@
                 FontSize="18"
                 HorizontalOptions="End"
                 VerticalOptions="Start"/>
-
+            
+            
+            
             <Image
                 Source="logo.png"
                 SemanticProperties.Description="the logo for identity purposes idk"
@@ -36,7 +38,14 @@
                 SemanticProperties.Description="Welcome to RevMetrix Bowling Assistant"
                 FontSize="18"
                 HorizontalOptions="Center" />
-
+            
+            <Label x:Name="UsrDisplay"
+                Text ="{Binding user}"
+                SemanticProperties.HeadingLevel="Level2"
+                SemanticProperties.Description="Dynamically Display Username"
+                FontSize="18"
+                HorizontalOptions="Center" />
+            
             <Button 
                 x:Name="NextBtn"
                 Text="Get Stats"

--- a/MauiApp2/MainPage.xaml.cs
+++ b/MauiApp2/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Plugin.BLE;
+﻿
+using Plugin.BLE;
 using Plugin.BLE.Abstractions.Contracts;
 using Plugin.BLE.Abstractions.EventArgs;
 using Plugin.BLE.Abstractions.Extensions;
@@ -7,6 +8,7 @@ namespace MauiApp2;
 
 public partial class MainPage : ContentPage
 {
+    string user = "N/A";
     public MainPage()
     {
         InitializeComponent();
@@ -20,6 +22,20 @@ public partial class MainPage : ContentPage
         };
     }
     Boolean bt;
+    public MainPage(String usernm)
+    {
+        InitializeComponent();
+        IBluetoothLE ble = CrossBluetoothLE.Current;
+        BluetoothState blue = ble.State;
+        BlueStat.Text = $"Bluetooth: {blue}";
+        ble.StateChanged += (s, e) =>
+        {
+            BluetoothState blue = ble.State;
+            BlueStat.Text = $"Bluetooth: {blue}";
+        };
+        user = usernm;
+        UsrDisplay.Text = $"Hello {user}!";
+    }
     
     private void OnBTClicked(object sender, EventArgs e) //bluetooth connection button
     {

--- a/MauiApp2/SimPage.xaml.cs
+++ b/MauiApp2/SimPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TextChangedEventArgs = Microsoft.Maui.Controls.TextChangedEventArgs;
 
 namespace MauiApp2;
 


### PR DESCRIPTION
Passing data screen to screen requires a new constructor and specifying the data values within the PushAsync that is called to propogate the viewer to the new screen, I've left an example of how to do this in LoginPage and MainPage